### PR TITLE
extended peptide quantification to all peptides

### DIFF
--- a/csodiaq/__init__.py
+++ b/csodiaq/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.7'
+__version__ = '1.2.0'
 
 from csodiaq import csodiaq_gui, csodiaq, csodiaq_identification_functions, csodiaq_mgf_cleaning_functions, \
     csodiaq_quantification_functions, idpicker, IdentificationSpectraMatcher, spectra_matcher_functions

--- a/csodiaq/csodiaq.py
+++ b/csodiaq/csodiaq.py
@@ -75,12 +75,12 @@ def main():
         # Post-processing
         # Check whether we should do anything
         if args['commonpeptide']:
-            print('Extracting peptides common across output files...', flush=True)
-            peptide_quantification.get_peptide_quantities(file_list=args['files'],
-                                                          library_file=args['library'],
-                                                          csodiaq_output_dir=args['outDirectory'],
-                                                          num_library_fragments=args['peaks'],
-                                                          save_file=os.path.join(args['outDirectory'], 'common_peptides.csv'))
+            print(f'Performing protein quantification and identifying common peptpides...', flush=True)
+            peptide_quantification.get_all_peptide_quantities(file_list=args['files'],
+                                                              library_file=args['library'],
+                                                              csodiaq_output_dir=args['outDirectory'],
+                                                              num_library_fragments=args['peaks'],
+                                                              save_file=os.path.join(args['outDirectory'], 'common_peptides.csv'))
             print('Done.')
         if args['commonprotein']:
             print('Extracting proteins common across output files...', flush=True)

--- a/csodiaq/plotting/spectra.py
+++ b/csodiaq/plotting/spectra.py
@@ -30,7 +30,9 @@ def spectrum_lineplot(spectrum: Spectrum,
     if not positive:
         intensity = [-i for i in intensity]
     plt.vlines(spectrum.mz, [0]*len(intensity), intensity, colors=color, label=label)
-    plt.hlines(0, min(spectrum.mz), max(spectrum.mz), colors='black')
+    x_min, x_max = plt.xlim()
+    plt.hlines(0, x_min, x_max, colors='black')
+    plt.xlim(x_min, x_max)
     return
 
 


### PR DESCRIPTION
- quantifies all peptides identified in the CsoDIAq files
- updates the CsoDIAq peptideFDR files once quantified (ionCount column)
- Saves the 'common_peptides.csv' file, containing the peptides common across the inputs